### PR TITLE
Add CRE glossary datapoints with hover-over info icons

### DIFF
--- a/backend/src/main/java/com/collateraltracker/backend/controller/CREGlossaryController.java
+++ b/backend/src/main/java/com/collateraltracker/backend/controller/CREGlossaryController.java
@@ -1,0 +1,31 @@
+package com.collateraltracker.backend.controller;
+
+import com.collateraltracker.backend.model.CREGlossaryTerm;
+import com.collateraltracker.backend.service.CREGlossaryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/glossary")
+public class CREGlossaryController {
+    
+    @Autowired
+    private CREGlossaryService glossaryService;
+    
+    @GetMapping
+    public ResponseEntity<List<CREGlossaryTerm>> getAllTerms() {
+        return ResponseEntity.ok(glossaryService.getAllTerms());
+    }
+    
+    @GetMapping("/{term}")
+    public ResponseEntity<CREGlossaryTerm> getTermByName(@PathVariable String term) {
+        CREGlossaryTerm glossaryTerm = glossaryService.getTermByName(term);
+        if (glossaryTerm == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(glossaryTerm);
+    }
+}

--- a/backend/src/main/java/com/collateraltracker/backend/model/CREGlossaryTerm.java
+++ b/backend/src/main/java/com/collateraltracker/backend/model/CREGlossaryTerm.java
@@ -1,0 +1,43 @@
+package com.collateraltracker.backend.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "cre_glossary_terms")
+public class CREGlossaryTerm {
+    @Id
+    private String id;
+    private String term;
+    private String definition;
+    
+    public CREGlossaryTerm() {}
+    
+    public CREGlossaryTerm(String term, String definition) {
+        this.term = term;
+        this.definition = definition;
+    }
+    
+    public String getId() {
+        return id;
+    }
+    
+    public void setId(String id) {
+        this.id = id;
+    }
+    
+    public String getTerm() {
+        return term;
+    }
+    
+    public void setTerm(String term) {
+        this.term = term;
+    }
+    
+    public String getDefinition() {
+        return definition;
+    }
+    
+    public void setDefinition(String definition) {
+        this.definition = definition;
+    }
+}

--- a/backend/src/main/java/com/collateraltracker/backend/model/CollateralItem.java
+++ b/backend/src/main/java/com/collateraltracker/backend/model/CollateralItem.java
@@ -4,6 +4,8 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @Document(collection = "collateral_items")
 public class CollateralItem {
@@ -16,6 +18,12 @@ public class CollateralItem {
     private LocalDate appraisalDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    
+    private Map<String, Object> creDatapoints;
+    
+    public CollateralItem() {
+        this.creDatapoints = new HashMap<>();
+    }
     
     public String getId() {
         return id;
@@ -63,5 +71,27 @@ public class CollateralItem {
     
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+    
+    public Map<String, Object> getCreDatapoints() {
+        return creDatapoints;
+    }
+    
+    public void setCreDatapoints(Map<String, Object> creDatapoints) {
+        this.creDatapoints = creDatapoints;
+    }
+    
+    public void setCreDatapoint(String key, Object value) {
+        if (this.creDatapoints == null) {
+            this.creDatapoints = new HashMap<>();
+        }
+        this.creDatapoints.put(key, value);
+    }
+    
+    public Object getCreDatapoint(String key) {
+        if (this.creDatapoints == null) {
+            return null;
+        }
+        return this.creDatapoints.get(key);
     }
 }

--- a/backend/src/main/java/com/collateraltracker/backend/repository/CREGlossaryTermRepository.java
+++ b/backend/src/main/java/com/collateraltracker/backend/repository/CREGlossaryTermRepository.java
@@ -1,0 +1,8 @@
+package com.collateraltracker.backend.repository;
+
+import com.collateraltracker.backend.model.CREGlossaryTerm;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface CREGlossaryTermRepository extends MongoRepository<CREGlossaryTerm, String> {
+    CREGlossaryTerm findByTerm(String term);
+}

--- a/backend/src/main/java/com/collateraltracker/backend/service/CREGlossaryService.java
+++ b/backend/src/main/java/com/collateraltracker/backend/service/CREGlossaryService.java
@@ -1,0 +1,60 @@
+package com.collateraltracker.backend.service;
+
+import com.collateraltracker.backend.model.CREGlossaryTerm;
+import com.collateraltracker.backend.repository.CREGlossaryTermRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+@Service
+public class CREGlossaryService {
+    
+    @Autowired
+    private CREGlossaryTermRepository glossaryTermRepository;
+    
+    public List<CREGlossaryTerm> getAllTerms() {
+        return glossaryTermRepository.findAll();
+    }
+    
+    public CREGlossaryTerm getTermByName(String term) {
+        return glossaryTermRepository.findByTerm(term);
+    }
+    
+    public CREGlossaryTerm saveTerm(CREGlossaryTerm term) {
+        return glossaryTermRepository.save(term);
+    }
+    
+    @PostConstruct
+    public void initializeGlossaryTerms() {
+        if (glossaryTermRepository.count() > 0) {
+            return;
+        }
+        
+        saveGlossaryTerm("10 Year Treasury", "The US 10-year Treasury Yield at the end of the reflected time period.");
+        saveGlossaryTerm("1031 Exchange", "A property that is eligible for a 1031 exchange.");
+        saveGlossaryTerm("1031 Replacement Property", "A property purchased with the proceeds from the sale of another property recently sold by the buyer, so as to qualify the sale and subsequent purchase as a 1031 exchange.");
+        saveGlossaryTerm("12-Month Rolling Metro Cap Rate", "12-Month Rolling Cap Rates are calculated from the average of the metro's mean cap rate from the previous four quarters.");
+        saveGlossaryTerm("Appraised Date Underwritten", "The date the Valuation Amount at Contribution was determined.");
+        saveGlossaryTerm("Appraised Value Current", "Code used to identify the source of the most recent property valuation. See CMBS Data Dictionary.");
+        saveGlossaryTerm("Appraised Value Underwritten", "The valuation amount of the property as of the Valuation Date at Contribution.");
+        saveGlossaryTerm("Arm's Length Transaction", "A transaction between unrelated parties under no duress.");
+        saveGlossaryTerm("Asking Rent", "The rental rate at which a space is being marketed for lease.");
+        saveGlossaryTerm("Building Class", "Classification of a building's quality, typically A, B, or C grade.");
+        saveGlossaryTerm("Additional Financing Original Balance", "The original balance of any additional financing on the property.");
+        saveGlossaryTerm("Additional Income", "Income generated from sources other than rent.");
+        saveGlossaryTerm("Affordable Housing Sector", "Properties designated for low-income residents with rent restrictions.");
+        saveGlossaryTerm("Amortization Type", "The method by which the loan principal is reduced over time.");
+        saveGlossaryTerm("Anchor Tenant", "A major tenant that serves as a primary draw for a commercial property.");
+        saveGlossaryTerm("Annualized", "A figure that has been mathematically converted to represent an annual rate.");
+        saveGlossaryTerm("Apartment Sector", "The segment of real estate focused on residential rental properties.");
+        saveGlossaryTerm("APN", "Assessor's Parcel Number - unique identifier assigned by the tax assessor.");
+        saveGlossaryTerm("Appraisal Date Current", "The date of the most recent property appraisal.");
+    }
+    
+    private void saveGlossaryTerm(String term, String definition) {
+        CREGlossaryTerm glossaryTerm = new CREGlossaryTerm(term, definition);
+        glossaryTermRepository.save(glossaryTerm);
+    }
+}

--- a/backend/src/main/java/com/collateraltracker/backend/service/CollateralService.java
+++ b/backend/src/main/java/com/collateraltracker/backend/service/CollateralService.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -60,6 +62,29 @@ public class CollateralService {
                     if (updatedItem.getAppraisalDate() != null && !updatedItem.getAppraisalDate().equals(existingItem.getAppraisalDate())) {
                         saveHistory(existingItem.getId(), "appraisalDate", existingItem.getAppraisalDate(), updatedItem.getAppraisalDate());
                         existingItem.setAppraisalDate(updatedItem.getAppraisalDate());
+                    }
+                    
+                    Map<String, Object> updatedDatapoints = updatedItem.getCreDatapoints();
+                    if (updatedDatapoints != null) {
+                        Map<String, Object> existingDatapoints = existingItem.getCreDatapoints();
+                        if (existingDatapoints == null) {
+                            existingDatapoints = new HashMap<>();
+                        }
+                        
+                        for (Map.Entry<String, Object> entry : updatedDatapoints.entrySet()) {
+                            String key = entry.getKey();
+                            Object newValue = entry.getValue();
+                            Object oldValue = existingDatapoints.get(key);
+                            
+                            if ((oldValue == null && newValue != null) || 
+                                (oldValue != null && !oldValue.equals(newValue))) {
+                                String oldValueStr = oldValue != null ? oldValue.toString() : "null";
+                                String newValueStr = newValue != null ? newValue.toString() : "null";
+                                saveHistory(existingItem.getId(), key, oldValueStr, newValueStr);
+                            }
+                        }
+                        
+                        existingItem.setCreDatapoints(updatedDatapoints);
                     }
                     
                     existingItem.setUpdatedAt(LocalDateTime.now());

--- a/frontend/src/api/collateralApi.ts
+++ b/frontend/src/api/collateralApi.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:8080/api/collateral';
+const API_URL = 'http://localhost:8080/api';
 
 export interface CollateralItem {
   id?: string;
@@ -9,6 +9,13 @@ export interface CollateralItem {
   appraisalDate: string;
   createdAt?: string;
   updatedAt?: string;
+  creDatapoints?: Record<string, any>;
+}
+
+export interface CREGlossaryTerm {
+  id: string;
+  term: string;
+  definition: string;
 }
 
 export interface CollateralHistory {
@@ -46,6 +53,11 @@ export const updateCollateralItem = async (id: string, item: CollateralItem): Pr
 };
 
 export const getCollateralHistory = async (id: string): Promise<CollateralHistory[]> => {
-  const response = await axios.get(`${API_URL}/${id}/history`);
+  const response = await axios.get(`${API_URL}/collateral/${id}/history`);
+  return response.data;
+};
+
+export const getAllGlossaryTerms = async (): Promise<CREGlossaryTerm[]> => {
+  const response = await axios.get(`${API_URL}/glossary`);
   return response.data;
 };

--- a/frontend/src/components/collateral/CollateralForm.tsx
+++ b/frontend/src/components/collateral/CollateralForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
@@ -13,11 +13,14 @@ import {
 } from "../../components/ui/dialog";
 import { 
   CollateralItem, 
+  CREGlossaryTerm,
   createCollateralItem, 
   updateCollateralItem, 
-  getCollateralItemByName 
+  getCollateralItemByName,
+  getAllGlossaryTerms
 } from '../../api/collateralApi';
 import { Calendar } from 'lucide-react';
+import { InfoIcon } from '../../components/ui/info-icon';
 
 interface CollateralFormProps {
   onSuccess?: () => void;
@@ -45,6 +48,22 @@ const CollateralForm: React.FC<CollateralFormProps> = ({
   const [success, setSuccess] = useState('');
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
+  
+  const [glossaryTerms, setGlossaryTerms] = useState<CREGlossaryTerm[]>([]);
+  const [creDatapoints, setCreDatapoints] = useState<Record<string, any>>({});
+
+  useEffect(() => {
+    const fetchGlossaryTerms = async () => {
+      try {
+        const terms = await getAllGlossaryTerms();
+        setGlossaryTerms(terms);
+      } catch (err) {
+        console.error('Failed to fetch glossary terms', err);
+      }
+    };
+    
+    fetchGlossaryTerms();
+  }, []);
 
   const resetForm = () => {
     setName('');
@@ -54,6 +73,7 @@ const CollateralForm: React.FC<CollateralFormProps> = ({
     setLocalIsUpdate(false);
     setError('');
     setSuccess('');
+    setCreDatapoints({});
   };
 
   const handleSearch = async () => {
@@ -68,13 +88,28 @@ const CollateralForm: React.FC<CollateralFormProps> = ({
       setName(item.name);
       setValue(item.value.toString());
       setAppraisalDate(item.appraisalDate);
+      
+      if (item.creDatapoints) {
+        setCreDatapoints(item.creDatapoints);
+      } else {
+        setCreDatapoints({});
+      }
+      
       setLocalIsUpdate(true);
       setError('');
     } catch (err) {
       setError('Collateral item not found');
       setCurrentItem(null);
       setLocalIsUpdate(false);
+      setCreDatapoints({});
     }
+  };
+  
+  const handleDatapointChange = (term: string, value: any) => {
+    setCreDatapoints(prev => ({
+      ...prev,
+      [term]: value
+    }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -119,7 +154,8 @@ const CollateralForm: React.FC<CollateralFormProps> = ({
       const collateralItem: CollateralItem = {
         name,
         value: parseFloat(value),
-        appraisalDate: appraisalDate
+        appraisalDate: appraisalDate,
+        creDatapoints: creDatapoints
       };
 
       if (localIsUpdate && currentItem?.id) {
@@ -224,6 +260,26 @@ const CollateralForm: React.FC<CollateralFormProps> = ({
                   }}
                 />
                 <Calendar className="absolute right-3 top-2.5 h-5 w-5 text-gray-400" />
+              </div>
+            </div>
+
+            <div className="mt-8 mb-4">
+              <h3 className="text-lg font-medium mb-4">CRE Datapoints</h3>
+              <div className="space-y-4">
+                {glossaryTerms.map((term) => (
+                  <div key={term.id} className="space-y-2">
+                    <div className="flex items-center space-x-2">
+                      <Label htmlFor={`cre-${term.term}`}>{term.term}</Label>
+                      <InfoIcon content={term.definition} />
+                    </div>
+                    <Input
+                      id={`cre-${term.term}`}
+                      value={creDatapoints[term.term] || ''}
+                      onChange={(e) => handleDatapointChange(term.term, e.target.value)}
+                      placeholder={`Enter ${term.term}`}
+                    />
+                  </div>
+                ))}
               </div>
             </div>
 

--- a/frontend/src/components/collateral/CollateralList.tsx
+++ b/frontend/src/components/collateral/CollateralList.tsx
@@ -3,10 +3,11 @@ import { Link } from 'react-router-dom';
 import { Button } from "../../components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
-import { CollateralItem, getAllCollateralItems, getCollateralHistory } from '../../api/collateralApi';
+import { CollateralItem, CREGlossaryTerm, getAllCollateralItems, getCollateralHistory, getAllGlossaryTerms } from '../../api/collateralApi';
 import { format } from 'date-fns';
-import { Eye, Edit } from 'lucide-react';
+import { Eye, Edit, ChevronDown, ChevronUp } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "../../components/ui/dialog";
+import { InfoIcon } from '../../components/ui/info-icon';
 
 interface CollateralListProps {
   searchResult?: CollateralItem | null;
@@ -19,6 +20,8 @@ const CollateralList: React.FC<CollateralListProps> = ({ searchResult, onUpdate 
   const [error, setError] = useState('');
   const [historyData, setHistoryData] = useState<any[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
+  const [glossaryTerms, setGlossaryTerms] = useState<CREGlossaryTerm[]>([]);
+  const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({});
 
   const fetchCollateralItems = async () => {
     setLoading(true);
@@ -51,8 +54,28 @@ const CollateralList: React.FC<CollateralListProps> = ({ searchResult, onUpdate 
   };
 
   useEffect(() => {
+    const fetchGlossaryTerms = async () => {
+      try {
+        const terms = await getAllGlossaryTerms();
+        setGlossaryTerms(terms);
+      } catch (err) {
+        console.error('Failed to fetch glossary terms', err);
+      }
+    };
+    
+    fetchGlossaryTerms();
+  }, []);
+
+  useEffect(() => {
     fetchCollateralItems();
   }, [searchResult]);
+  
+  const toggleExpandItem = (itemId: string) => {
+    setExpandedItems(prev => ({
+      ...prev,
+      [itemId]: !prev[itemId]
+    }));
+  };
 
   const handleViewHistory = (id: string) => {
     fetchHistory(id);
@@ -93,73 +116,119 @@ const CollateralList: React.FC<CollateralListProps> = ({ searchResult, onUpdate 
                 <TableHead>Value</TableHead>
                 <TableHead>Appraisal Date</TableHead>
                 <TableHead>Last Updated</TableHead>
+                <TableHead>CRE Datapoints</TableHead>
                 <TableHead>Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {collateralItems.map((item) => (
-                <TableRow key={item.id}>
-                  <TableCell>{item.name}</TableCell>
-                  <TableCell>${item.value.toFixed(2)}</TableCell>
-                  <TableCell>{formatDate(item.appraisalDate)}</TableCell>
-                  <TableCell>{item.updatedAt ? formatDate(item.updatedAt) : 'N/A'}</TableCell>
-                  <TableCell>
-                    <div className="flex space-x-2">
-                      <Dialog>
-                        <DialogTrigger asChild>
-                          <Button 
-                            variant="outline" 
-                            size="sm"
-                          >
-                            <Eye className="h-4 w-4 mr-1" /> History
-                          </Button>
-                        </DialogTrigger>
-                        <DialogContent className="max-w-3xl" onOpenAutoFocus={(e) => {
-                          e.preventDefault();
-                          if (item.id) {
-                            handleViewHistory(item.id);
-                          }
-                        }}>
-                          <DialogHeader>
-                            <DialogTitle>History for {item.name}</DialogTitle>
-                          </DialogHeader>
-                          {historyLoading ? (
-                            <p>Loading history...</p>
-                          ) : historyData.length === 0 ? (
-                            <p>No history records found for this item.</p>
-                          ) : (
-                            <Table>
-                              <TableHeader>
-                                <TableRow>
-                                  <TableHead>Field</TableHead>
-                                  <TableHead>Old Value</TableHead>
-                                  <TableHead>New Value</TableHead>
-                                  <TableHead>Changed At</TableHead>
-                                </TableRow>
-                              </TableHeader>
-                              <TableBody>
-                                {historyData.map((record) => (
-                                  <TableRow key={record.id}>
-                                    <TableCell>{record.fieldName}</TableCell>
-                                    <TableCell>{record.oldValue}</TableCell>
-                                    <TableCell>{record.newValue}</TableCell>
-                                    <TableCell>{formatDate(record.changedAt)}</TableCell>
-                                  </TableRow>
-                                ))}
-                              </TableBody>
-                            </Table>
-                          )}
-                        </DialogContent>
-                      </Dialog>
-                      <Link to={`/update/${item.id}`}>
-                        <Button variant="outline" size="sm">
-                          <Edit className="h-4 w-4 mr-1" /> Update
+              {collateralItems.map((item) => {
+                const isExpanded = item.id && expandedItems[item.id];
+                const hasDatapoints = item.creDatapoints && Object.keys(item.creDatapoints || {}).length > 0;
+                
+                return (
+                  <React.Fragment key={item.id}>
+                    <TableRow>
+                      <TableCell>{item.name}</TableCell>
+                      <TableCell>${item.value.toFixed(2)}</TableCell>
+                      <TableCell>{formatDate(item.appraisalDate)}</TableCell>
+                      <TableCell>{item.updatedAt ? formatDate(item.updatedAt) : 'N/A'}</TableCell>
+                      <TableCell>
+                        <Button 
+                          variant="ghost" 
+                          size="sm" 
+                          onClick={() => item.id && toggleExpandItem(item.id)}
+                          className="flex items-center"
+                        >
+                          {hasDatapoints ? 
+                            `${Object.keys(item.creDatapoints || {}).length} datapoints` : 
+                            'No datapoints'}
+                          {isExpanded ? 
+                            <ChevronUp className="ml-1 h-4 w-4" /> : 
+                            <ChevronDown className="ml-1 h-4 w-4" />}
                         </Button>
-                      </Link>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex space-x-2">
+                          <Dialog>
+                            <DialogTrigger asChild>
+                              <Button 
+                                variant="outline" 
+                                size="sm"
+                              >
+                                <Eye className="h-4 w-4 mr-1" /> History
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent className="max-w-3xl" onOpenAutoFocus={(e) => {
+                              e.preventDefault();
+                              if (item.id) {
+                                handleViewHistory(item.id);
+                              }
+                            }}>
+                              <DialogHeader>
+                                <DialogTitle>History for {item.name}</DialogTitle>
+                              </DialogHeader>
+                              {historyLoading ? (
+                                <p>Loading history...</p>
+                              ) : historyData.length === 0 ? (
+                                <p>No history records found for this item.</p>
+                              ) : (
+                                <Table>
+                                  <TableHeader>
+                                    <TableRow>
+                                      <TableHead>Field</TableHead>
+                                      <TableHead>Old Value</TableHead>
+                                      <TableHead>New Value</TableHead>
+                                      <TableHead>Changed At</TableHead>
+                                    </TableRow>
+                                  </TableHeader>
+                                  <TableBody>
+                                    {historyData.map((record) => (
+                                      <TableRow key={record.id}>
+                                        <TableCell>{record.fieldName}</TableCell>
+                                        <TableCell>{record.oldValue}</TableCell>
+                                        <TableCell>{record.newValue}</TableCell>
+                                        <TableCell>{formatDate(record.changedAt)}</TableCell>
+                                      </TableRow>
+                                    ))}
+                                  </TableBody>
+                                </Table>
+                              )}
+                            </DialogContent>
+                          </Dialog>
+                          <Link to={`/update/${item.id}`}>
+                            <Button variant="outline" size="sm">
+                              <Edit className="h-4 w-4 mr-1" /> Update
+                            </Button>
+                          </Link>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                    {isExpanded && hasDatapoints && (
+                      <TableRow>
+                        <TableCell colSpan={6} className="bg-gray-50">
+                          <div className="p-4">
+                            <h4 className="text-sm font-medium mb-2">CRE Datapoints</h4>
+                            <div className="grid grid-cols-2 gap-4">
+                              {Object.entries(item.creDatapoints || {}).map(([key, value]) => {
+                                const term = glossaryTerms.find(t => t.term === key);
+                                return (
+                                  <div key={key} className="flex flex-col space-y-1">
+                                    <div className="flex items-center space-x-1">
+                                      <span className="text-sm font-medium">{key}</span>
+                                      {term && <InfoIcon content={term.definition} />}
+                                    </div>
+                                    <span className="text-sm">{value?.toString() || 'N/A'}</span>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </React.Fragment>
+                );
+              })}
             </TableBody>
           </Table>
         )}

--- a/frontend/src/components/ui/info-icon.tsx
+++ b/frontend/src/components/ui/info-icon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Info } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
+
+interface InfoIconProps {
+  content: string;
+  className?: string;
+}
+
+export const InfoIcon: React.FC<InfoIconProps> = ({ content, className }) => {
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <span className={`inline-flex cursor-help items-center ${className || ''}`}>
+            <Info className="h-4 w-4 text-zinc-500" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs text-xs">
+          <p>{content}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};


### PR DESCRIPTION
This PR adds CRE glossary datapoints to collateral items with hover-over info icons for definitions.

## Changes
- Added CREGlossaryTerm model, repository, service, and controller
- Modified CollateralItem to include dynamic creDatapoints map
- Updated CollateralService to track changes in datapoints
- Created InfoIcon component for hover-over definitions
- Updated CollateralForm to include CRE datapoints fields
- Updated CollateralList to display expandable datapoints
- Added API interfaces for glossary term fetching

Note: MongoDB connection issue needs to be resolved for backend functionality.

Link to Devin run: https://app.devin.ai/sessions/43186f0d7cf44296b3bc546f2b930e86
Requested by: johnathan.cassady@ny.email.gs.com